### PR TITLE
Add language code to output SRT filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,15 @@ python SubLingo_1.2.py
 Los archivos traducidos se guardan en:
 ```
 ./output_traducidos/
-├── archivo1_traducido.ass
+├── archivo1_traducido.es-419.ass
 ├── subcarpeta/
-│   └── archivo2_traducido.srt
+│   └── archivo2_traducido.es-419.srt
 └── ...
 ```
+
+El código de idioma (`es-419` en el ejemplo) se agrega al nombre de cada
+archivo para que herramientas como **MKVToolNix** detecten automáticamente
+el idioma.
 
 La estructura de carpetas original se mantiene intacta.
 

--- a/SubLingo_1.2.py
+++ b/SubLingo_1.2.py
@@ -251,7 +251,14 @@ async def translate_file(path: Path, translator: GeminiTranslator, src_lang: str
     # Guardar
     out_path = OUTPUT_ROOT / path.relative_to(Path.cwd())
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    subs.save(out_path, encoding="utf-8", format_="ass" if path.suffix.lower() == ".ass" else "srt")
+
+    # Insertar el código de idioma en el nombre para que MKVToolNix lo detecte
+    out_path = out_path.with_name(f"{out_path.stem}.{tgt_lang}{out_path.suffix}")
+    subs.save(
+        out_path,
+        encoding="utf-8",
+        format_="ass" if path.suffix.lower() == ".ass" else "srt",
+    )
 
     progress.update(parent_task, advance=1)
 


### PR DESCRIPTION
## Summary
- update output path naming in `SubLingo_1.2.py` so MKVToolNix can detect the language
- document new naming convention in the README

## Testing
- `python3 -m py_compile SubLingo_1.2.py`

------
https://chatgpt.com/codex/tasks/task_e_685774359968832698c94353c4e26467